### PR TITLE
Fixing rulers to the window

### DIFF
--- a/rulersguides.css
+++ b/rulersguides.css
@@ -62,7 +62,7 @@ html,body {
 
 .ruler {
     background-color: #ccc;
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     z-index: 9990


### PR DESCRIPTION
Changed the position->"absolute" for the class->".ruler" to->"fixed",
for beetter usability on large pages, if you could scroll on the page vertical or horizontal.
Otherwise you have to scroll to the top of a page and drag and drop each line for more than a page lenght.
